### PR TITLE
Adiciona senha ao Boleto

### DIFF
--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -95,6 +95,8 @@ module Brcobranca
       attr_accessor :carne
       # <b>OPCIONAL</b>: Detalhes do qrcode para o PIX
       attr_accessor :pix_details
+      # <b>OPCIONAL</b>: Senha para o boleto
+      attr_accessor :senha
 
       # Validações
       validates_presence_of :agencia, :conta_corrente, :moeda, :especie_documento, :especie, :aceite, :nosso_numero,

--- a/lib/brcobranca/boleto/base.rb
+++ b/lib/brcobranca/boleto/base.rb
@@ -95,8 +95,10 @@ module Brcobranca
       attr_accessor :carne
       # <b>OPCIONAL</b>: Detalhes do qrcode para o PIX
       attr_accessor :pix_details
-      # <b>OPCIONAL</b>: Senha para o boleto
-      attr_accessor :senha
+      # <b>OPCIONAL</b>: Senha do usuário para o boleto
+      attr_accessor :senha_usuario
+      # <b>OPCIONAL</b>: Senha do proprietário para o boleto
+      attr_accessor :senha_proprietario
 
       # Validações
       validates_presence_of :agencia, :conta_corrente, :moeda, :especie_documento, :especie, :aceite, :nosso_numero,
@@ -234,6 +236,12 @@ module Brcobranca
       # @abstract Deverá ser sobreescrito para cada banco.
       def codigo_barras_segunda_parte
         raise Brcobranca::NaoImplementado, 'Sobreescreva este método na classe referente ao banco que você esta criando'
+      end
+
+      # Senha aplicada no PDF do boleto.
+      # @return [Boolean]
+      def usa_senha?
+        senha_usuario.present? && senha_proprietario.present?
       end
 
       private

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -71,6 +71,12 @@ module Brcobranca
         def modelo_generico(boleto, options = {})
           doc = Document.new paper: :A4 # 210x297
 
+          doc.security do |sec|
+            sec.owner_password = boleto.senha
+            sec.user_password = boleto.senha
+            sec.key_length = 128
+          end unless boleto.senha.blank?
+
           with_logo = boleto.recipient_logo_details.present?
           template_name = with_logo ? 'modelo_generico_logo.eps' : 'modelo_generico.eps'
           with_pix = boleto.pix_details.present?
@@ -106,6 +112,12 @@ module Brcobranca
         # @option options [Symbol] :formato Formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
         def modelo_generico_multipage(boletos, options = {})
           doc = Document.new paper: :A4 # 210x297
+
+          doc.security do |sec|
+            sec.owner_password = boletos.first.senha
+            sec.user_password = boletos.first.senha
+            sec.key_length = 128
+          end unless boletos.first.senha.blank?
 
           template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico.eps')
 

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -72,10 +72,10 @@ module Brcobranca
           doc = Document.new paper: :A4 # 210x297
 
           doc.security do |sec|
-            sec.owner_password = boleto.senha
-            sec.user_password = boleto.senha
+            sec.owner_password = boleto.senha_proprietario
+            sec.user_password = boleto.senha_usuario
             sec.key_length = 128
-          end unless boleto.senha.blank?
+          end if boleto.usa_senha?
 
           with_logo = boleto.recipient_logo_details.present?
           template_name = with_logo ? 'modelo_generico_logo.eps' : 'modelo_generico.eps'
@@ -114,10 +114,10 @@ module Brcobranca
           doc = Document.new paper: :A4 # 210x297
 
           doc.security do |sec|
-            sec.owner_password = boletos.first.senha
-            sec.user_password = boletos.first.senha
+            sec.owner_password = boletos.first.senha_proprietario
+            sec.user_password = boletos.first.senha_usuario
             sec.key_length = 128
-          end unless boletos.first.senha.blank?
+          end if boletos.first.usa_senha?
 
           template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico.eps')
 

--- a/lib/brcobranca/boleto/template/rghost2.rb
+++ b/lib/brcobranca/boleto/template/rghost2.rb
@@ -72,6 +72,13 @@ begin
           # @option options [Symbol] :formato Formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
           def modelo_generico(boleto, options = {})
             doc = Document.new paper: [21,29.7] # A4
+
+            doc.security do |sec|
+              sec.owner_password = boleto.senha
+              sec.user_password = boleto.senha
+              sec.key_length = 128
+            end unless boleto.senha.blank?
+
             template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico2.eps')
             raise 'Não foi possível encontrar o template. Verifique o caminho' unless File.exist?(template_path)
             modelo_recibo_beneficiario(doc, boleto)
@@ -93,6 +100,13 @@ begin
           # @option options [Symbol] :formato Formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
           def modelo_generico_multipage(boletos, options = {})
             doc = Document.new paper: [21,29.7] # A4
+
+            doc.security do |sec|
+              sec.owner_password = boletos.first.senha
+              sec.user_password = boletos.first.senha
+              sec.key_length = 128
+            end unless boletos.first.senha.blank?
+
             template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico2.eps')
             raise 'Não foi possível encontrar o template. Verifique o caminho' unless File.exist?(template_path)
             boletos.each_with_index do |boleto, index|

--- a/lib/brcobranca/boleto/template/rghost2.rb
+++ b/lib/brcobranca/boleto/template/rghost2.rb
@@ -74,10 +74,10 @@ begin
             doc = Document.new paper: [21,29.7] # A4
 
             doc.security do |sec|
-              sec.owner_password = boleto.senha
-              sec.user_password = boleto.senha
+              sec.owner_password = boleto.senha_proprietario
+              sec.user_password = boleto.senha_usuario
               sec.key_length = 128
-            end unless boleto.senha.blank?
+            end if boleto.usa_senha?
 
             template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico2.eps')
             raise 'Não foi possível encontrar o template. Verifique o caminho' unless File.exist?(template_path)
@@ -102,10 +102,10 @@ begin
             doc = Document.new paper: [21,29.7] # A4
 
             doc.security do |sec|
-              sec.owner_password = boletos.first.senha
-              sec.user_password = boletos.first.senha
+              sec.owner_password = boletos.first.senha_proprietario
+              sec.user_password = boletos.first.senha_usuario
               sec.key_length = 128
-            end unless boletos.first.senha.blank?
+            end if boletos.first.usa_senha?
 
             template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico2.eps')
             raise 'Não foi possível encontrar o template. Verifique o caminho' unless File.exist?(template_path)

--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -71,6 +71,12 @@ module Brcobranca
         def modelo_carne(boleto, options = {})
           doc = Document.new paper: [21, 9]
 
+          doc.security do |sec|
+            sec.owner_password = boleto.senha
+            sec.user_password = boleto.senha
+            sec.key_length = 128
+          end unless boleto.senha.blank?
+
           colunas = calc_colunas 1
           linhas = calc_linhas 0
 
@@ -96,6 +102,12 @@ module Brcobranca
         # @option options [Symbol] :formato Formato desejado [:pdf, :jpg, :tif, :png, :ps, :laserjet, ... etc]
         def modelo_carne_multipage(boletos, options = {})
           doc = Document.new paper: :A4
+
+          doc.security do |sec|
+            sec.owner_password = boletos.first.senha
+            sec.user_password = boletos.first.senha
+            sec.key_length = 128
+          end unless boletos.first.senha.blank?
 
           max_per_page = 3
           curr_page_position = 0

--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -72,10 +72,10 @@ module Brcobranca
           doc = Document.new paper: [21, 9]
 
           doc.security do |sec|
-            sec.owner_password = boleto.senha
-            sec.user_password = boleto.senha
+            sec.owner_password = boleto.senha_proprietario
+            sec.user_password = boleto.senha_usuario
             sec.key_length = 128
-          end unless boleto.senha.blank?
+          end if boleto.usa_senha?
 
           colunas = calc_colunas 1
           linhas = calc_linhas 0
@@ -104,10 +104,10 @@ module Brcobranca
           doc = Document.new paper: :A4
 
           doc.security do |sec|
-            sec.owner_password = boletos.first.senha
-            sec.user_password = boletos.first.senha
+            sec.owner_password = boletos.first.senha_proprietario
+            sec.user_password = boletos.first.senha_usuario
             sec.key_length = 128
-          end unless boletos.first.senha.blank?
+          end if boletos.first.usa_senha?
 
           max_per_page = 3
           curr_page_position = 0

--- a/lib/brcobranca/version.rb
+++ b/lib/brcobranca/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Brcobranca
-  VERSION = '10.1.2'
+  VERSION = '10.2.0'
 end

--- a/spec/brcobranca/base_spec.rb
+++ b/spec/brcobranca/base_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::Base do
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       especie_documento: 'DM',
       moeda: '9',
       aceite: 'S',
@@ -39,7 +39,7 @@ RSpec.describe Brcobranca::Boleto::Base do
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
     expect(boleto_novo.moeda).to eql('9')
@@ -63,7 +63,7 @@ RSpec.describe Brcobranca::Boleto::Base do
   end
 
   it 'Calcula agencia_dv' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     boleto_novo.agencia = '85068014982'
     expect(boleto_novo.agencia_dv).to be(9)
     boleto_novo.agencia = '05009401448'
@@ -91,7 +91,7 @@ RSpec.describe Brcobranca::Boleto::Base do
   end
 
   it 'Calcula conta_corrente_dv' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     boleto_novo.conta_corrente = '85068014982'
     expect(boleto_novo.conta_corrente_dv).to be(9)
     boleto_novo.conta_corrente = '05009401448'
@@ -119,7 +119,7 @@ RSpec.describe Brcobranca::Boleto::Base do
   end
 
   it 'Calcula o valor do documento' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     boleto_novo.quantidade = 1
     boleto_novo.valor = 1
     expect(boleto_novo.valor_documento).to eq(1.0)
@@ -141,7 +141,7 @@ RSpec.describe Brcobranca::Boleto::Base do
   end
 
   it 'Mostrar aviso sobre sobrecarga de métodos padrões' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect do
       boleto_novo.codigo_barras_segunda_parte
     end.to raise_error(Brcobranca::NaoImplementado,

--- a/spec/brcobranca/boleto/ailos_spec.rb
+++ b/spec/brcobranca/boleto/ailos_spec.rb
@@ -145,4 +145,8 @@ RSpec.describe Brcobranca::Boleto::Ailos do # :nodoc:[all]
   describe 'Formato do boleto' do
     it_behaves_like 'formatos_validos'
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/ailos_spec.rb
+++ b/spec/brcobranca/boleto/ailos_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::Ailos do # :nodoc:[all]
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 0.0,
       local_pagamento: 'Pagar preferencialmente nas cooperativas do Sistema AILOS.',
       cedente: 'Kivanio Barbosa',
@@ -24,36 +24,36 @@ RSpec.describe Brcobranca::Boleto::Ailos do # :nodoc:[all]
   end
 
   it 'Tamanho do número da agência deve ser de 4 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(agencia: '0101')
+    boleto_novo = described_class.new valid_attributes.merge(agencia: '0101')
     expect(boleto_novo.agencia).to eq('0101')
 
-    boleto_novo = described_class.new @valid_attributes.merge(agencia: '00001')
+    boleto_novo = described_class.new valid_attributes.merge(agencia: '00001')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Tamanho do número de convênio deve ser de 6 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(convenio: '1234567')
+    boleto_novo = described_class.new valid_attributes.merge(convenio: '1234567')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Tamanho da carteira deve ser de 2 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(carteira: '01')
+    boleto_novo = described_class.new valid_attributes.merge(carteira: '01')
     expect(boleto_novo).to be_valid
 
-    boleto_novo = described_class.new @valid_attributes.merge(carteira: '112')
+    boleto_novo = described_class.new valid_attributes.merge(carteira: '112')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Tamanho do número documento deve ser de 9 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '123456789')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '123456789')
     expect(boleto_novo).to be_valid
 
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '1234567890')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '1234567890')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Número do documento deve ser preenchido com zeros à esquerda quando menor que 9 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '1')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '1')
     expect(boleto_novo.nosso_numero).to eq('000000001')
     expect(boleto_novo).to be_valid
   end
@@ -76,7 +76,7 @@ RSpec.describe Brcobranca::Boleto::Ailos do # :nodoc:[all]
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.banco).to eql('085')
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
@@ -101,19 +101,19 @@ RSpec.describe Brcobranca::Boleto::Ailos do # :nodoc:[all]
   end
 
   it 'Montar código de barras' do
-    @valid_attributes[:valor] = 1.00
-    @valid_attributes[:data_documento] = Date.parse('2015-02-03')
-    @valid_attributes[:data_vencimento] = Date.parse('2015-05-25')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 1.00
+    valid_attributes[:data_documento] = Date.parse('2015-02-03')
+    valid_attributes[:data_vencimento] = Date.parse('2015-05-25')
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0000001111111900000000101')
     expect(boleto_novo.codigo_barras).to eql('08593643900000001000000001111111900000000101')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('08590.00002 01111.111900 00000.001016 3 64390000000100')
     expect(boleto_novo.conta_corrente_dv).to be(9)
 
-    @valid_attributes[:convenio] = '234'
-    @valid_attributes[:conta_corrente] = '356156'
-    segundo_boleto = described_class.new(@valid_attributes)
+    valid_attributes[:convenio] = '234'
+    valid_attributes[:conta_corrente] = '356156'
+    segundo_boleto = described_class.new(valid_attributes)
 
     expect(segundo_boleto.codigo_barras_segunda_parte).to eql('0002340356156900000000101')
     expect(segundo_boleto.codigo_barras).to eql('08593643900000001000002340356156900000000101')
@@ -121,14 +121,14 @@ RSpec.describe Brcobranca::Boleto::Ailos do # :nodoc:[all]
   end
 
   it 'Montar nosso_numero_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     boleto_novo.conta_corrente = '0357157'
     boleto_novo.nosso_numero = '1'
     expect(boleto_novo.nosso_numero_boleto).to eql('03571572000000001')
   end
 
   it 'Montar agencia_conta_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_boleto).to eql('0101-5 / 1111111-9')
     boleto_novo.agencia = '0719'

--- a/spec/brcobranca/boleto/banco_brasil_spec.rb
+++ b/spec/brcobranca/boleto/banco_brasil_spec.rb
@@ -333,4 +333,8 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/banco_brasil_spec.rb
+++ b/spec/brcobranca/boleto/banco_brasil_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 0.0,
       local_pagamento: 'QUALQUER BANCO ATÉ O VENCIMENTO',
       cedente: 'Kivanio Barbosa',
@@ -36,7 +36,7 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.banco).to eql('001')
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
@@ -61,10 +61,10 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Montar código de barras para convenio de 8 digitos e nosso número de 9' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0000001238798977770016818')
     expect(boleto_novo.codigo_barras).to eql('00193376900000135000000001238798977770016818')
@@ -72,9 +72,9 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
     expect(boleto_novo.conta_corrente_dv).to be(0)
     expect(boleto_novo.nosso_numero_dv).to be(7)
 
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-02')
-    @valid_attributes[:nosso_numero] = '7700168'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-02')
+    valid_attributes[:nosso_numero] = '7700168'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0000001238798900770016818')
     expect(boleto_novo.codigo_barras).to eql('00193377000000135000000001238798900770016818')
@@ -84,36 +84,36 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Montar código de barras para convenio de 7 digitos e nosso numero de 10' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
-    @valid_attributes[:convenio] = 1_238_798
-    @valid_attributes[:nosso_numero] = '7777700168'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
+    valid_attributes[:convenio] = 1_238_798
+    valid_attributes[:nosso_numero] = '7777700168'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0000001238798777770016818')
     expect(boleto_novo.codigo_barras).to eql('00193377100000135000000001238798777770016818')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('00190.00009 01238.798779 77700.168188 3 37710000013500')
     expect(boleto_novo.conta_corrente_dv).to be(0)
 
-    @valid_attributes[:valor] = 723.56
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
-    @valid_attributes[:convenio] = 1_238_798
-    @valid_attributes[:nosso_numero] = '7777700168'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 723.56
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
+    valid_attributes[:convenio] = 1_238_798
+    valid_attributes[:nosso_numero] = '7777700168'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0000001238798777770016818')
     expect(boleto_novo.codigo_barras).to eql('00195377100000723560000001238798777770016818')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('00190.00009 01238.798779 77700.168188 5 37710000072356')
     expect(boleto_novo.conta_corrente_dv).to be(0)
 
-    @valid_attributes[:valor] = 723.56
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
-    @valid_attributes[:convenio] = 1_238_798
-    @valid_attributes[:nosso_numero] = '7777700168'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 723.56
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
+    valid_attributes[:convenio] = 1_238_798
+    valid_attributes[:nosso_numero] = '7777700168'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0000001238798777770016818')
     expect(boleto_novo.codigo_barras).to eql('00194376900000723560000001238798777770016818')
@@ -122,12 +122,12 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Montar código de barras para convenio de 6 digitos e nosso numero de 5' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
-    @valid_attributes[:convenio] = 123_879
-    @valid_attributes[:nosso_numero] = '1234'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
+    valid_attributes[:convenio] = 123_879
+    valid_attributes[:nosso_numero] = '1234'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.conta_corrente_dv).to be(0)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1238790123440420006190018')
@@ -136,14 +136,14 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Montar código de barras para convenio de 6 digitos, nosso numero de 17 e carteira 16' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
-    @valid_attributes[:convenio] = 123_879
-    @valid_attributes[:nosso_numero] = '1234567899'
-    @valid_attributes[:carteira] = '16'
-    @valid_attributes[:codigo_servico] = true
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
+    valid_attributes[:convenio] = 123_879
+    valid_attributes[:nosso_numero] = '1234567899'
+    valid_attributes[:carteira] = '16'
+    valid_attributes[:codigo_servico] = true
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.conta_corrente_dv).to be(0)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1238790000000123456789921')
@@ -152,14 +152,14 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Montar código de barras para convenio de 6 digitos, nosso numero de 17 e carteira 18' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
-    @valid_attributes[:convenio] = 123_879
-    @valid_attributes[:nosso_numero] = '1234567899'
-    @valid_attributes[:carteira] = '18'
-    @valid_attributes[:codigo_servico] = true
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
+    valid_attributes[:convenio] = 123_879
+    valid_attributes[:nosso_numero] = '1234567899'
+    valid_attributes[:carteira] = '18'
+    valid_attributes[:codigo_servico] = true
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.conta_corrente_dv).to be(0)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1238790000000123456789921')
@@ -168,14 +168,14 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Não montar código de barras para convenio de 6 digitos, nosso numero de 17 e carteira 17' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
-    @valid_attributes[:convenio] = 123_879
-    @valid_attributes[:nosso_numero] = '1234567899'
-    @valid_attributes[:carteira] = '17'
-    @valid_attributes[:codigo_servico] = true
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
+    valid_attributes[:convenio] = 123_879
+    valid_attributes[:nosso_numero] = '1234567899'
+    valid_attributes[:carteira] = '17'
+    valid_attributes[:codigo_servico] = true
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.conta_corrente_dv).to be(0)
     expect { boleto_novo.codigo_barras_segunda_parte }.to raise_error(RuntimeError)
@@ -185,13 +185,13 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Montar código de barras para convenio de 4 digitos e nosso numero de 7' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
-    @valid_attributes[:convenio] = 1238
-    @valid_attributes[:nosso_numero] = '123456'
-    @valid_attributes[:codigo_servico] = true
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
+    valid_attributes[:convenio] = 1238
+    valid_attributes[:nosso_numero] = '123456'
+    valid_attributes[:codigo_servico] = true
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.conta_corrente_dv).to be(0)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1238012345640420006190018')
@@ -232,7 +232,7 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Calcular agencia_dv' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     boleto_novo.agencia = '85068014982'
     expect(boleto_novo.agencia_dv).to be(9)
     boleto_novo.agencia = '05009401448'
@@ -260,7 +260,7 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Montar nosso_numero_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     boleto_novo.nosso_numero = '4042'
     expect(boleto_novo.nosso_numero_boleto).to eql('12387989000004042')
     expect(boleto_novo.nosso_numero_dv).to be(4)
@@ -282,7 +282,7 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Montar agencia_conta_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_boleto).to eql('4042-8 / 00061900-0')
     boleto_novo.agencia = '0719'
@@ -297,12 +297,12 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Gerar boleto nos formatos válidos com método to_' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
-    @valid_attributes[:convenio] = 1_238_798
-    @valid_attributes[:nosso_numero] = '7777700168'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
+    valid_attributes[:convenio] = 1_238_798
+    valid_attributes[:nosso_numero] = '7777700168'
+    boleto_novo = described_class.new(valid_attributes)
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.send("to_#{format}".to_sym)
       tmp_file = Tempfile.new(['foobar.', format])
@@ -316,12 +316,12 @@ RSpec.describe Brcobranca::Boleto::BancoBrasil do # :nodoc:[all]
   end
 
   it 'Gerar boleto nos formatos válidos' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
-    @valid_attributes[:convenio] = 1_238_798
-    @valid_attributes[:nosso_numero] = '7777700168'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
+    valid_attributes[:convenio] = 1_238_798
+    valid_attributes[:nosso_numero] = '7777700168'
+    boleto_novo = described_class.new(valid_attributes)
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.to(format)
       tmp_file = Tempfile.new(['foobar.', format])

--- a/spec/brcobranca/boleto/banco_brasilia_spec.rb
+++ b/spec/brcobranca/boleto/banco_brasilia_spec.rb
@@ -150,4 +150,8 @@ RSpec.describe Brcobranca::Boleto::BancoBrasilia do # :nodoc:[all]
 
     it_behaves_like 'formatos_validos'
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/banco_brasilia_spec.rb
+++ b/spec/brcobranca/boleto/banco_brasilia_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::BancoBrasilia do # :nodoc:[all]
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 10.00,
       cedente: 'PREFEITURA MUNICIPAL DE VILHENA',
       documento_cedente: '04092706000181',
@@ -34,33 +34,33 @@ RSpec.describe Brcobranca::Boleto::BancoBrasilia do # :nodoc:[all]
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new @valid_attributes
-    @valid_attributes.each_key do |key|
-      expect(boleto_novo.send(key)).to eql(@valid_attributes[key])
+    boleto_novo = described_class.new valid_attributes
+    valid_attributes.each_key do |key|
+      expect(boleto_novo.send(key)).to eql(valid_attributes[key])
     end
     expect(boleto_novo).to be_valid
   end
 
   it 'Gerar o código de barras' do
-    @valid_attributes[:data_documento] = Date.parse('2015-04-30')
-    @valid_attributes[:data_vencimento] = Date.parse('2015-04-30')
+    valid_attributes[:data_documento] = Date.parse('2015-04-30')
+    valid_attributes[:data_vencimento] = Date.parse('2015-04-30')
 
-    boleto_novo = described_class.new @valid_attributes
+    boleto_novo = described_class.new valid_attributes
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0000820000528200000107013')
     expect(boleto_novo.codigo_barras).to eql('07099641400000010000000820000528200000107013')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('07090.00087 20000.528206 00001.070135 9 64140000001000')
 
-    @valid_attributes[:data_documento] = Date.parse('2016-07-25')
-    @valid_attributes[:data_vencimento] = Date.parse('2016-07-25')
-    @valid_attributes[:valor] = 372.77
-    @valid_attributes[:carteira] = 1
-    @valid_attributes[:agencia] = 240
-    @valid_attributes[:conta_corrente] = 44_990
-    @valid_attributes[:nosso_numero] = 1
-    @valid_attributes[:nosso_numero_incremento] = 2
+    valid_attributes[:data_documento] = Date.parse('2016-07-25')
+    valid_attributes[:data_vencimento] = Date.parse('2016-07-25')
+    valid_attributes[:valor] = 372.77
+    valid_attributes[:carteira] = 1
+    valid_attributes[:agencia] = 240
+    valid_attributes[:conta_corrente] = 44_990
+    valid_attributes[:nosso_numero] = 1
+    valid_attributes[:nosso_numero_incremento] = 2
 
-    boleto_novo = described_class.new @valid_attributes
+    boleto_novo = described_class.new valid_attributes
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0022400044990100000107070')
     expect(boleto_novo.codigo_barras).to eql('07099686600000372770022400044990100000107070')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('07090.02240 00044.990109 00001.070705 9 68660000037277')
@@ -72,62 +72,62 @@ RSpec.describe Brcobranca::Boleto::BancoBrasilia do # :nodoc:[all]
   end
 
   it 'Tamanho do número da agência deve ser de 3 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(agencia: '80')
+    boleto_novo = described_class.new valid_attributes.merge(agencia: '80')
     expect(boleto_novo.agencia).to eq('080')
 
-    boleto_novo = described_class.new @valid_attributes.merge(agencia: '0080')
+    boleto_novo = described_class.new valid_attributes.merge(agencia: '0080')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Tamanho do número de nosso_numero_incremento deve ser de 3 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero_incremento: '12345678')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero_incremento: '12345678')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Tamanho do número de conta corrente deve ser de 7 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(conta_corrente: '12345678')
+    boleto_novo = described_class.new valid_attributes.merge(conta_corrente: '12345678')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Número do conta corrente deve ser preenchido com zeros à esquerda quando menor que 7 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(conta_corrente: '12345')
+    boleto_novo = described_class.new valid_attributes.merge(conta_corrente: '12345')
     expect(boleto_novo.conta_corrente).to eq('0012345')
     expect(boleto_novo).to be_valid
   end
 
   it 'Tamanho da carteira deve ser de 1 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(carteira: '145')
+    boleto_novo = described_class.new valid_attributes.merge(carteira: '145')
     expect(boleto_novo).not_to be_valid
 
-    boleto_novo = described_class.new @valid_attributes.merge(carteira: '24')
+    boleto_novo = described_class.new valid_attributes.merge(carteira: '24')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Tamanho do número documento deve ser de 6 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '1234567')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '1234567')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Número do documento deve ser preenchido com zeros à esquerda quando menor que 6 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '1')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '1')
     expect(boleto_novo.nosso_numero).to eq('000001')
     expect(boleto_novo).to be_valid
   end
 
   it 'Montar nosso_numero_boleto' do
-    boleto_novo = described_class.new @valid_attributes
+    boleto_novo = described_class.new valid_attributes
     expect(boleto_novo.nosso_numero_boleto).to eq('200000107013')
 
-    @valid_attributes[:carteira] = 1
-    @valid_attributes[:agencia] = '058'
-    @valid_attributes[:conta_corrente] = 6_002_006
-    @valid_attributes[:nosso_numero] = 1
-    boleto_novo = described_class.new @valid_attributes
+    valid_attributes[:carteira] = 1
+    valid_attributes[:agencia] = '058'
+    valid_attributes[:conta_corrente] = 6_002_006
+    valid_attributes[:nosso_numero] = 1
+    boleto_novo = described_class.new valid_attributes
     expect(boleto_novo.nosso_numero_boleto).to eq('100000107045')
   end
 
   it 'Montar agencia_conta_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_boleto).to eql('000 - 082 - 0000528')
 
@@ -145,7 +145,7 @@ RSpec.describe Brcobranca::Boleto::BancoBrasilia do # :nodoc:[all]
 
   describe 'Formato do boleto' do
     before do
-      @valid_attributes[:nosso_numero] = '000168'
+      valid_attributes[:nosso_numero] = '000168'
     end
 
     it_behaves_like 'formatos_validos'

--- a/spec/brcobranca/boleto/banco_nordeste_spec.rb
+++ b/spec/brcobranca/boleto/banco_nordeste_spec.rb
@@ -157,4 +157,8 @@ RSpec.describe Brcobranca::Boleto::BancoNordeste do # :nodoc:[all]
   describe 'Formato do boleto' do
     it_behaves_like 'formatos_validos'
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/banco_nordeste_spec.rb
+++ b/spec/brcobranca/boleto/banco_nordeste_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::BancoNordeste do # :nodoc:[all]
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 25.0,
       local_pagamento: 'QUALQUER BANCO ATÉ O VENCIMENTO',
       cedente: 'Kivanio Barbosa',
@@ -35,7 +35,7 @@ RSpec.describe Brcobranca::Boleto::BancoNordeste do # :nodoc:[all]
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.banco).to eql('004')
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
@@ -57,39 +57,39 @@ RSpec.describe Brcobranca::Boleto::BancoNordeste do # :nodoc:[all]
   end
 
   it 'Gerar boleto' do
-    @valid_attributes[:valor] = 1000.00
-    @valid_attributes[:data_vencimento] = Date.parse('2009/10/21')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 1000.00
+    valid_attributes[:data_vencimento] = Date.parse('2009/10/21')
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0016000119320000053121000')
     expect(boleto_novo.codigo_barras).to eql('00491439700001000000016000119320000053121000')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('00490.01605 00119.320000 00531.210003 1 43970000100000')
 
-    @valid_attributes[:valor] = 54.00
-    @valid_attributes[:nosso_numero] = '0002720'
-    @valid_attributes[:data_vencimento] = Date.parse('2012/09/08')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 54.00
+    valid_attributes[:nosso_numero] = '0002720'
+    valid_attributes[:data_vencimento] = Date.parse('2012/09/08')
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0016000119320002720021000')
     expect(boleto_novo.codigo_barras).to eql('00497545000000054000016000119320002720021000')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('00490.01605 00119.320000 27200.210006 7 54500000005400')
 
-    @valid_attributes[:agencia] = '0259'
-    @valid_attributes[:conta_corrente] = '0008549'
-    @valid_attributes[:digito_conta_corrente] = '3'
-    @valid_attributes[:valor] = 1.01
-    @valid_attributes[:nosso_numero] = '0000001'
-    @valid_attributes[:data_vencimento] = Date.parse('2017/01/17')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:agencia] = '0259'
+    valid_attributes[:conta_corrente] = '0008549'
+    valid_attributes[:digito_conta_corrente] = '3'
+    valid_attributes[:valor] = 1.01
+    valid_attributes[:nosso_numero] = '0000001'
+    valid_attributes[:data_vencimento] = Date.parse('2017/01/17')
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0259000854930000001921000')
     expect(boleto_novo.codigo_barras).to eql('00492704200000001010259000854930000001921000')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('00490.25901 00854.930005 00019.210004 2 70420000000101')
 
-    @valid_attributes[:agencia] = '0275'
-    @valid_attributes[:conta_corrente] = '0000253'
-    @valid_attributes[:digito_conta_corrente] = '5'
-    @valid_attributes[:valor] = 2807.75
-    @valid_attributes[:nosso_numero] = '0000005'
-    @valid_attributes[:data_vencimento] = Date.parse('2016/07/28')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:agencia] = '0275'
+    valid_attributes[:conta_corrente] = '0000253'
+    valid_attributes[:digito_conta_corrente] = '5'
+    valid_attributes[:valor] = 2807.75
+    valid_attributes[:nosso_numero] = '0000005'
+    valid_attributes[:data_vencimento] = Date.parse('2016/07/28')
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0275000025350000005121000')
     expect(boleto_novo.codigo_barras).to eql('00491686900002807750275000025350000005121000')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('00490.27501 00025.350000 00051.210003 1 68690000280775')
@@ -102,51 +102,51 @@ RSpec.describe Brcobranca::Boleto::BancoNordeste do # :nodoc:[all]
   end
 
   it 'Montar nosso_numero_dv' do
-    @valid_attributes[:nosso_numero] = '9061138'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '9061138'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to be(1)
 
-    @valid_attributes[:nosso_numero] = '0000010'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '0000010'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to be(8)
 
-    @valid_attributes[:nosso_numero] = '0020572'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '0020572'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to be(9)
 
-    @valid_attributes[:nosso_numero] = '1961005'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '1961005'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to be(0)
 
-    @valid_attributes[:nosso_numero] = '0000053'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '0000053'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to be(1)
   end
 
   it 'Montar nosso_numero_boleto' do
-    @valid_attributes[:nosso_numero] = '0000010'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '0000010'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_boleto).to eql('0000010-8')
 
-    @valid_attributes[:nosso_numero] = '0020572'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '0020572'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_boleto).to eql('0020572-9')
 
-    @valid_attributes[:nosso_numero] = '1297105'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '1297105'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_boleto).to eql('1297105-7')
 
-    @valid_attributes[:nosso_numero] = '0000005'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '0000005'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_boleto).to eql('0000005-1')
 
-    @valid_attributes[:nosso_numero] = '0020572'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '0020572'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_boleto).to eql('0020572-9')
   end
 
   it 'Montar agencia_conta_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.agencia_conta_boleto).to eql('0016/0001193-2')
   end
 

--- a/spec/brcobranca/boleto/banestes_spec.rb
+++ b/spec/brcobranca/boleto/banestes_spec.rb
@@ -190,4 +190,8 @@ RSpec.describe Brcobranca::Boleto::Banestes do # :nodoc:[all]
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/banrisul_spec.rb
+++ b/spec/brcobranca/boleto/banrisul_spec.rb
@@ -177,4 +177,8 @@ RSpec.describe Brcobranca::Boleto::Banrisul do # :nodoc:[all]
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/bradesco_spec.rb
+++ b/spec/brcobranca/boleto/bradesco_spec.rb
@@ -211,4 +211,8 @@ RSpec.describe Brcobranca::Boleto::Bradesco do
       expect(described_class.new(conta_corrente: '0301357').conta_corrente_dv).to eq('P')
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/caixa_spec.rb
+++ b/spec/brcobranca/boleto/caixa_spec.rb
@@ -157,4 +157,8 @@ RSpec.describe Brcobranca::Boleto::Caixa do # :nodoc:[all]
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/caixa_spec.rb
+++ b/spec/brcobranca/boleto/caixa_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::Caixa do # :nodoc:[all]
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 10.00,
       cedente: 'PREFEITURA MUNICIPAL DE VILHENA',
       documento_cedente: '04092706000181',
@@ -37,21 +37,21 @@ RSpec.describe Brcobranca::Boleto::Caixa do # :nodoc:[all]
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new @valid_attributes
-    @valid_attributes.each_key do |key|
-      expect(boleto_novo.send(key)).to eql(@valid_attributes[key])
+    boleto_novo = described_class.new valid_attributes
+    valid_attributes.each_key do |key|
+      expect(boleto_novo.send(key)).to eql(valid_attributes[key])
     end
     expect(boleto_novo).to be_valid
   end
 
   it 'Gerar o dígito verificador do convênio' do
-    boleto_novo = described_class.new @valid_attributes
+    boleto_novo = described_class.new valid_attributes
     expect(boleto_novo.convenio_dv).not_to be_nil
     expect(boleto_novo.convenio_dv).to eq('0')
   end
 
   it 'Gerar o código de barras' do
-    boleto_novo = described_class.new @valid_attributes
+    boleto_novo = described_class.new valid_attributes
     expect { boleto_novo.codigo_barras }.not_to raise_error
     expect(boleto_novo.codigo_barras_segunda_parte).not_to be_blank
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('2452740000100040000000017')
@@ -63,50 +63,50 @@ RSpec.describe Brcobranca::Boleto::Caixa do # :nodoc:[all]
   end
 
   it 'Tamanho do número de convênio deve ser de 6 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(convenio: '1234567')
+    boleto_novo = described_class.new valid_attributes.merge(convenio: '1234567')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Número do convênio deve ser preenchido com zeros à esquerda quando menor que 6 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(convenio: '12345')
+    boleto_novo = described_class.new valid_attributes.merge(convenio: '12345')
     expect(boleto_novo.convenio).to eq('012345')
     expect(boleto_novo).to be_valid
   end
 
   it 'Tamanho da carteira deve ser de 1 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(carteira: '145')
+    boleto_novo = described_class.new valid_attributes.merge(carteira: '145')
     expect(boleto_novo).not_to be_valid
 
-    boleto_novo = described_class.new @valid_attributes.merge(carteira: '24')
+    boleto_novo = described_class.new valid_attributes.merge(carteira: '24')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Emissao deve ser de 1 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(emissao: '145')
+    boleto_novo = described_class.new valid_attributes.merge(emissao: '145')
     expect(boleto_novo).not_to be_valid
 
-    boleto_novo = described_class.new @valid_attributes.merge(emissao: '24')
+    boleto_novo = described_class.new valid_attributes.merge(emissao: '24')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Tamanho do número documento deve ser de 15 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '1234567891234567')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '1234567891234567')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Número do documento deve ser preenchido com zeros à esquerda quando menor que 15 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '1')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '1')
     expect(boleto_novo.nosso_numero).to eq('000000000000001')
     expect(boleto_novo).to be_valid
   end
 
   it 'Montar nosso_numero_boleto' do
-    boleto_novo = described_class.new @valid_attributes
+    boleto_novo = described_class.new valid_attributes
     expect(boleto_novo.nosso_numero_boleto).to eq('14000000000000001-4')
   end
 
   it 'Montar agencia_conta_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_boleto).to eql('1825/245274-0')
 
@@ -123,11 +123,11 @@ RSpec.describe Brcobranca::Boleto::Caixa do # :nodoc:[all]
   end
 
   it 'Gerar boleto nos formatos válidos com método to_' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
-    @valid_attributes[:nosso_numero] = '000000077700168'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
+    valid_attributes[:nosso_numero] = '000000077700168'
+    boleto_novo = described_class.new(valid_attributes)
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.send("to_#{format}".to_sym)
       tmp_file = Tempfile.new(['foobar.', format])
@@ -141,11 +141,11 @@ RSpec.describe Brcobranca::Boleto::Caixa do # :nodoc:[all]
   end
 
   it 'Gerar boleto nos formatos válidos' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
-    @valid_attributes[:nosso_numero] = '000000077700168'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
+    valid_attributes[:nosso_numero] = '000000077700168'
+    boleto_novo = described_class.new(valid_attributes)
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.to(format)
       tmp_file = Tempfile.new(['foobar.', format])

--- a/spec/brcobranca/boleto/citibank_spec.rb
+++ b/spec/brcobranca/boleto/citibank_spec.rb
@@ -192,4 +192,8 @@ RSpec.describe Brcobranca::Boleto::Citibank do # :nodoc:[all]
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/citibank_spec.rb
+++ b/spec/brcobranca/boleto/citibank_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::Citibank do # :nodoc:[all]
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 10.00,
       local_pagamento: 'QUALQUER BANCO ATÉ O VENCIMENTO',
       cedente: 'Kivanio Barbosa',
@@ -20,7 +20,7 @@ RSpec.describe Brcobranca::Boleto::Citibank do # :nodoc:[all]
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.banco).to eql('745')
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
@@ -44,7 +44,7 @@ RSpec.describe Brcobranca::Boleto::Citibank do # :nodoc:[all]
   end
 
   it 'Gerar o código de barras' do
-    boleto_novo = described_class.new @valid_attributes
+    boleto_novo = described_class.new valid_attributes
     expect { boleto_novo.codigo_barras }.not_to raise_error
     expect(boleto_novo.codigo_barras_segunda_parte).not_to be_blank
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('3650123456789000000000019')
@@ -56,40 +56,40 @@ RSpec.describe Brcobranca::Boleto::Citibank do # :nodoc:[all]
   end
 
   it 'Tamanho do número de convênio deve ser de 10 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(convenio: '12345678901')
+    boleto_novo = described_class.new valid_attributes.merge(convenio: '12345678901')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Número do convênio deve ser preenchido com zeros à esquerda quando menor que 6 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(convenio: '12345')
+    boleto_novo = described_class.new valid_attributes.merge(convenio: '12345')
     expect(boleto_novo.convenio).to eq('0000012345')
     expect(boleto_novo).to be_valid
   end
 
   it 'Tamanho do portfolio deve ser de 3 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(portfolio: '1454')
+    boleto_novo = described_class.new valid_attributes.merge(portfolio: '1454')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Portfolio deve ser preenchido com zeros à esquerda quando menor que 3 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(portfolio: '1')
+    boleto_novo = described_class.new valid_attributes.merge(portfolio: '1')
     expect(boleto_novo.portfolio).to eq('001')
     expect(boleto_novo).to be_valid
   end
 
   it 'Tamanho do número documento deve ser de 11 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '1234567891234567')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '1234567891234567')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Número do documento deve ser preenchido com zeros à esquerda quando menor que 1 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '1')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '1')
     expect(boleto_novo.nosso_numero).to eq('00000000001')
     expect(boleto_novo).to be_valid
   end
 
   it 'Montar nosso_numero_boleto' do
-    boleto_novo = described_class.new @valid_attributes
+    boleto_novo = described_class.new valid_attributes
     expect(boleto_novo.nosso_numero_boleto).to eq('00000000001.9')
 
     boleto_novo.nosso_numero = '66660000003'
@@ -97,7 +97,7 @@ RSpec.describe Brcobranca::Boleto::Citibank do # :nodoc:[all]
   end
 
   it 'Montar agencia_conta_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_boleto).to eql('1825 / 0123456789')
 
@@ -110,43 +110,43 @@ RSpec.describe Brcobranca::Boleto::Citibank do # :nodoc:[all]
   end
 
   it 'Montar código de barras' do
-    @valid_attributes[:valor] = 9.99
-    @valid_attributes[:data_documento] = Date.parse('2012-09-10')
-    @valid_attributes[:data_vencimento] = Date.parse('2012-09-10')
-    @valid_attributes[:agencia] = '0093'
-    @valid_attributes[:conta_corrente] = '21057486'
-    @valid_attributes[:convenio] = '0305080446'
-    @valid_attributes[:nosso_numero] = '00000000002'
-    @valid_attributes[:portfolio] = '621'
+    valid_attributes[:valor] = 9.99
+    valid_attributes[:data_documento] = Date.parse('2012-09-10')
+    valid_attributes[:data_vencimento] = Date.parse('2012-09-10')
+    valid_attributes[:agencia] = '0093'
+    valid_attributes[:conta_corrente] = '21057486'
+    valid_attributes[:convenio] = '0305080446'
+    valid_attributes[:nosso_numero] = '00000000002'
+    valid_attributes[:portfolio] = '621'
 
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('3621305080446000000000027')
     expect(boleto_novo.codigo_barras).to eql('74595545200000009993621305080446000000000027')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('74593.62138 05080.446007 00000.000273 5 54520000000999')
 
-    @valid_attributes[:valor] = 2.0
-    @valid_attributes[:data_documento] = Date.parse('2013-09-27')
-    @valid_attributes[:data_vencimento] = Date.parse('2013-09-27')
-    @valid_attributes[:agencia] = '0121'
-    @valid_attributes[:conta_corrente] = '22202129'
-    @valid_attributes[:convenio] = '0264424020'
-    @valid_attributes[:nosso_numero] = '00000000159'
-    @valid_attributes[:portfolio] = '611'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 2.0
+    valid_attributes[:data_documento] = Date.parse('2013-09-27')
+    valid_attributes[:data_vencimento] = Date.parse('2013-09-27')
+    valid_attributes[:agencia] = '0121'
+    valid_attributes[:conta_corrente] = '22202129'
+    valid_attributes[:convenio] = '0264424020'
+    valid_attributes[:nosso_numero] = '00000000159'
+    valid_attributes[:portfolio] = '611'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('3611264424020000000001597')
     expect(boleto_novo.codigo_barras).to eql('74591583400000002003611264424020000000001597')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('74593.61122 64424.020002 00000.015974 1 58340000000200')
 
-    @valid_attributes[:valor] = 774.30
-    @valid_attributes[:data_documento] = Date.parse('2013-11-20')
-    @valid_attributes[:data_vencimento] = Date.parse('2013-11-20')
-    @valid_attributes[:agencia] = '0121'
-    @valid_attributes[:conta_corrente] = '22202129'
-    @valid_attributes[:convenio] = '0264424020'
-    @valid_attributes[:nosso_numero] = '00000000200'
-    @valid_attributes[:portfolio] = '611'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 774.30
+    valid_attributes[:data_documento] = Date.parse('2013-11-20')
+    valid_attributes[:data_vencimento] = Date.parse('2013-11-20')
+    valid_attributes[:agencia] = '0121'
+    valid_attributes[:conta_corrente] = '22202129'
+    valid_attributes[:convenio] = '0264424020'
+    valid_attributes[:nosso_numero] = '00000000200'
+    valid_attributes[:portfolio] = '611'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('3611264424020000000002003')
     expect(boleto_novo.codigo_barras).to eql('74597588800000774303611264424020000000002003')
@@ -158,11 +158,11 @@ RSpec.describe Brcobranca::Boleto::Citibank do # :nodoc:[all]
   end
 
   it 'Gerar boleto nos formatos válidos com método to_' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
-    @valid_attributes[:nosso_numero] = '00077700168'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
+    valid_attributes[:nosso_numero] = '00077700168'
+    boleto_novo = described_class.new(valid_attributes)
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.send("to_#{format}".to_sym)
       tmp_file = Tempfile.new(['foobar.', format])
@@ -176,11 +176,11 @@ RSpec.describe Brcobranca::Boleto::Citibank do # :nodoc:[all]
   end
 
   it 'Gerar boleto nos formatos válidos' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
-    @valid_attributes[:nosso_numero] = '00077700168'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-03')
+    valid_attributes[:nosso_numero] = '00077700168'
+    boleto_novo = described_class.new(valid_attributes)
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.to(format)
       tmp_file = Tempfile.new(['foobar.', format])

--- a/spec/brcobranca/boleto/credisis_spec.rb
+++ b/spec/brcobranca/boleto/credisis_spec.rb
@@ -157,4 +157,8 @@ RSpec.describe Brcobranca::Boleto::Credisis do # :nodoc:[all]
   describe 'Formato do boleto' do
     it_behaves_like 'formatos_validos'
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/credisis_spec.rb
+++ b/spec/brcobranca/boleto/credisis_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::Credisis do # :nodoc:[all]
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 0.0,
       local_pagamento: 'QUALQUER BANCO ATÉ O VENCIMENTO',
       cedente: 'Kivanio Barbosa',
@@ -24,40 +24,40 @@ RSpec.describe Brcobranca::Boleto::Credisis do # :nodoc:[all]
   end
 
   it 'Tamanho do número da agência deve ser de 4 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(agencia: '0001')
+    boleto_novo = described_class.new valid_attributes.merge(agencia: '0001')
     expect(boleto_novo.agencia).to eq('0001')
 
-    boleto_novo = described_class.new @valid_attributes.merge(agencia: '00001')
+    boleto_novo = described_class.new valid_attributes.merge(agencia: '00001')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Tamanho do número de convênio deve ser de 7 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(convenio: '12345678')
+    boleto_novo = described_class.new valid_attributes.merge(convenio: '12345678')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Tamanho da carteira deve ser de 2 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(carteira: '145')
+    boleto_novo = described_class.new valid_attributes.merge(carteira: '145')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Tamanho do número documento deve ser de 6 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '1234567')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '1234567')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'documento_cedente nao pode estar em branco' do
-    boleto_novo = described_class.new @valid_attributes.merge(documento_cedente: nil)
+    boleto_novo = described_class.new valid_attributes.merge(documento_cedente: nil)
     expect(boleto_novo).not_to be_valid
   end
 
   it 'documento_cedente deve ter somente numeros' do
-    boleto_novo = described_class.new @valid_attributes.merge(documento_cedente: '123.456.789-12')
+    boleto_novo = described_class.new valid_attributes.merge(documento_cedente: '123.456.789-12')
     expect(boleto_novo).not_to be_valid
   end
 
   it 'Número do documento deve ser preenchido com zeros à esquerda quando menor que 6 dígitos' do
-    boleto_novo = described_class.new @valid_attributes.merge(nosso_numero: '1')
+    boleto_novo = described_class.new valid_attributes.merge(nosso_numero: '1')
     expect(boleto_novo.nosso_numero).to eq('000001')
     expect(boleto_novo).to be_valid
   end
@@ -79,7 +79,7 @@ RSpec.describe Brcobranca::Boleto::Credisis do # :nodoc:[all]
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.banco).to eql('097')
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
@@ -103,18 +103,18 @@ RSpec.describe Brcobranca::Boleto::Credisis do # :nodoc:[all]
   end
 
   it 'Montar código de barras' do
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:data_documento] = Date.parse('2008-02-01')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:data_documento] = Date.parse('2008-02-01')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0000009750001100000000095')
     expect(boleto_novo.codigo_barras).to eql('09791376900000135000000009750001100000000095')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('09790.00007 09750.001100 00000.000950 1 37690000013500')
     expect(boleto_novo.conta_corrente_dv).to be(7)
 
-    @valid_attributes[:convenio] = '6641'
-    segundo_boleto = described_class.new(@valid_attributes)
+    valid_attributes[:convenio] = '6641'
+    segundo_boleto = described_class.new(valid_attributes)
 
     expect(segundo_boleto.codigo_barras_segunda_parte).to eql('0000009750001006641000095')
     expect(segundo_boleto.codigo_barras).to eql('09797376900000135000000009750001006641000095')
@@ -122,7 +122,7 @@ RSpec.describe Brcobranca::Boleto::Credisis do # :nodoc:[all]
   end
 
   it 'Calcular agencia_dv' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     boleto_novo.agencia = '4042'
     expect(boleto_novo.agencia_dv).to be(8)
     boleto_novo.agencia = '0719'
@@ -134,13 +134,13 @@ RSpec.describe Brcobranca::Boleto::Credisis do # :nodoc:[all]
   end
 
   it 'Montar nosso_numero_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     boleto_novo.nosso_numero = '95'
     expect(boleto_novo.nosso_numero_boleto).to eql('09750001100000000095')
   end
 
   it 'Montar agencia_conta_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_boleto).to eql('0001-9 / 0000002-7')
     boleto_novo.agencia = '0719'

--- a/spec/brcobranca/boleto/hsbc_spec.rb
+++ b/spec/brcobranca/boleto/hsbc_spec.rb
@@ -168,4 +168,8 @@ RSpec.describe Brcobranca::Boleto::Hsbc do
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/hsbc_spec.rb
+++ b/spec/brcobranca/boleto/hsbc_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::Hsbc do
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 0.0,
       cedente: 'Kivanio Barbosa',
       documento_cedente: '12345678912',
@@ -34,7 +34,7 @@ RSpec.describe Brcobranca::Boleto::Hsbc do
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.banco).to eql('399')
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
@@ -58,22 +58,22 @@ RSpec.describe Brcobranca::Boleto::Hsbc do
   end
 
   it 'Gerar boleto' do
-    @valid_attributes[:valor] = 2952.95
-    @valid_attributes[:data_vencimento] = Date.parse('2009-04-08')
-    @valid_attributes[:nosso_numero] = '12345678'
-    @valid_attributes[:conta_corrente] = '1122334'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 2952.95
+    valid_attributes[:data_vencimento] = Date.parse('2009-04-08')
+    valid_attributes[:nosso_numero] = '12345678'
+    valid_attributes[:conta_corrente] = '1122334'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1122334000001234567809892')
     expect(boleto_novo.codigo_barras).to eql('39998420100002952951122334000001234567809892')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('39991.12232 34000.001239 45678.098927 8 42010000295295')
 
-    @valid_attributes[:valor] = 934.23
-    @valid_attributes[:data_vencimento] = Date.parse('2004-09-03')
-    @valid_attributes[:nosso_numero] = '07778899'
-    @valid_attributes[:conta_corrente] = '0016324'
-    @valid_attributes[:agencia] = '1234'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 934.23
+    valid_attributes[:data_vencimento] = Date.parse('2004-09-03')
+    valid_attributes[:nosso_numero] = '07778899'
+    valid_attributes[:conta_corrente] = '0016324'
+    valid_attributes[:agencia] = '1234'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('0016324000000777889924742')
     expect(boleto_novo.codigo_barras).to eql('39993252300000934230016324000000777889924742')
@@ -87,37 +87,37 @@ RSpec.describe Brcobranca::Boleto::Hsbc do
   end
 
   it 'Montar nosso_numero_boleto' do
-    @valid_attributes[:data_vencimento] = Date.parse('2000-07-09')
-    @valid_attributes[:nosso_numero] = '12345678'
-    @valid_attributes[:conta_corrente] = '1122334'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_vencimento] = Date.parse('2000-07-09')
+    valid_attributes[:nosso_numero] = '12345678'
+    valid_attributes[:conta_corrente] = '1122334'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.nosso_numero_boleto).to eql('0000012345678942')
 
-    @valid_attributes[:data_vencimento] = Date.parse('2000-07-04')
-    @valid_attributes[:nosso_numero] = '39104766'
-    @valid_attributes[:conta_corrente] = '351202'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_vencimento] = Date.parse('2000-07-04')
+    valid_attributes[:nosso_numero] = '39104766'
+    valid_attributes[:conta_corrente] = '351202'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.nosso_numero_boleto).to eql('0000039104766340')
 
-    @valid_attributes[:data_vencimento] = Date.parse('2009-04-03')
-    @valid_attributes[:nosso_numero] = '39104766'
-    @valid_attributes[:conta_corrente] = '351202'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_vencimento] = Date.parse('2009-04-03')
+    valid_attributes[:nosso_numero] = '39104766'
+    valid_attributes[:conta_corrente] = '351202'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.nosso_numero_boleto).to eql('0000039104766346')
 
-    @valid_attributes[:data_vencimento] = nil
-    @valid_attributes[:nosso_numero] = '39104766'
-    @valid_attributes[:conta_corrente] = '351202'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_vencimento] = nil
+    valid_attributes[:nosso_numero] = '39104766'
+    valid_attributes[:conta_corrente] = '351202'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect { boleto_novo.nosso_numero_boleto }.to raise_error(Brcobranca::BoletoInvalido)
   end
 
   it 'Montar agencia_conta_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_boleto).to eql('0061900')
     boleto_novo.agencia = '0719'
@@ -132,11 +132,11 @@ RSpec.describe Brcobranca::Boleto::Hsbc do
   end
 
   it 'Gerar boleto nos formatos válidos com método to_' do
-    @valid_attributes[:valor] = 2952.95
-    @valid_attributes[:data_vencimento] = Date.parse('2009-04-08')
-    @valid_attributes[:nosso_numero] = '12345678'
-    @valid_attributes[:conta_corrente] = '1122334'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 2952.95
+    valid_attributes[:data_vencimento] = Date.parse('2009-04-08')
+    valid_attributes[:nosso_numero] = '12345678'
+    valid_attributes[:conta_corrente] = '1122334'
+    boleto_novo = described_class.new(valid_attributes)
 
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.send("to_#{format}".to_sym)
@@ -151,11 +151,11 @@ RSpec.describe Brcobranca::Boleto::Hsbc do
   end
 
   it 'Gerar boleto nos formatos válidos' do
-    @valid_attributes[:valor] = 2952.95
-    @valid_attributes[:data_vencimento] = Date.parse('2009-04-08')
-    @valid_attributes[:nosso_numero] = '12345678'
-    @valid_attributes[:conta_corrente] = '1122334'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 2952.95
+    valid_attributes[:data_vencimento] = Date.parse('2009-04-08')
+    valid_attributes[:nosso_numero] = '12345678'
+    valid_attributes[:conta_corrente] = '1122334'
+    boleto_novo = described_class.new(valid_attributes)
 
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.to(format)

--- a/spec/brcobranca/boleto/itau_spec.rb
+++ b/spec/brcobranca/boleto/itau_spec.rb
@@ -258,4 +258,8 @@ RSpec.describe Brcobranca::Boleto::Itau do
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/itau_spec.rb
+++ b/spec/brcobranca/boleto/itau_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::Itau do
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 0.0,
       cedente: 'Kivanio Barbosa',
       documento_cedente: '12345678912',
@@ -34,7 +34,7 @@ RSpec.describe Brcobranca::Boleto::Itau do
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.banco).to eql('341')
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
@@ -58,87 +58,87 @@ RSpec.describe Brcobranca::Boleto::Itau do
   end
 
   it '#usa_seu_numero?' do
-    @valid_attributes[:carteira] = 198
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:carteira] = 198
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo).to be_usa_seu_numero
 
-    @valid_attributes[:carteira] = 109
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:carteira] = 109
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo).not_to be_usa_seu_numero
   end
 
   it 'Gerar boleto' do
-    @valid_attributes[:data_vencimento] = Date.parse('2009/08/14')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_vencimento] = Date.parse('2009/08/14')
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1751234567840810536789000')
     expect(boleto_novo.codigo_barras).to eql('34191432900000000001751234567840810536789000')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('34191.75124 34567.840813 05367.890000 1 43290000000000')
 
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:nosso_numero] = '258281'
-    @valid_attributes[:data_vencimento] = Date.parse('2008/02/02')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:nosso_numero] = '258281'
+    valid_attributes[:data_vencimento] = Date.parse('2008/02/02')
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1750025828170810536789000')
     expect(boleto_novo.codigo_barras).to eql('34191377000000135001750025828170810536789000')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('34191.75009 25828.170818 05367.890000 1 37700000013500')
 
-    @valid_attributes[:nosso_numero] = '258281'
-    @valid_attributes[:data_vencimento] = Date.parse('2004/09/05')
-    @valid_attributes[:carteira] = 168
-    @valid_attributes[:valor] = 135.00
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '258281'
+    valid_attributes[:data_vencimento] = Date.parse('2004/09/05')
+    valid_attributes[:carteira] = 168
+    valid_attributes[:valor] = 135.00
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1680025828120810536789000')
     expect(boleto_novo.codigo_barras).to eql('34194252500000135001680025828120810536789000')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('34191.68004 25828.120813 05367.890000 4 25250000013500')
 
-    @valid_attributes[:nosso_numero] = '258281'
-    @valid_attributes[:data_vencimento] = Date.parse('2004/09/05')
-    @valid_attributes[:carteira] = 196
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:convenio] = '12345'
-    @valid_attributes[:seu_numero] = '1234567'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '258281'
+    valid_attributes[:data_vencimento] = Date.parse('2004/09/05')
+    valid_attributes[:carteira] = 196
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:convenio] = '12345'
+    valid_attributes[:seu_numero] = '1234567'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1960025828112345671234550')
     expect(boleto_novo.codigo_barras).to eql('34191252500000135001960025828112345671234550')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('34191.96005 25828.112349 56712.345505 1 25250000013500')
 
-    @valid_attributes[:nosso_numero] = '258281'
-    @valid_attributes[:data_vencimento] = Date.parse('2004/09/05')
-    @valid_attributes[:carteira] = 196
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:convenio] = '12345'
-    @valid_attributes[:seu_numero] = '123456'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '258281'
+    valid_attributes[:data_vencimento] = Date.parse('2004/09/05')
+    valid_attributes[:carteira] = 196
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:convenio] = '12345'
+    valid_attributes[:seu_numero] = '123456'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1960025828101234561234550')
     expect(boleto_novo.codigo_barras).to eql('34192252500000135001960025828101234561234550')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('34191.96005 25828.101235 45612.345509 2 25250000013500')
 
-    @valid_attributes[:nosso_numero] = '258281'
-    @valid_attributes[:data_vencimento] = Date.parse('2004/09/05')
-    @valid_attributes[:carteira] = 196
-    @valid_attributes[:valor] = 135.00
-    @valid_attributes[:convenio] = '1234'
-    @valid_attributes[:seu_numero] = '123456'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '258281'
+    valid_attributes[:data_vencimento] = Date.parse('2004/09/05')
+    valid_attributes[:carteira] = 196
+    valid_attributes[:valor] = 135.00
+    valid_attributes[:convenio] = '1234'
+    valid_attributes[:seu_numero] = '123456'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.send(:codigo_barras_primeira_parte)).to eql('341925250000013500')
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1960025828101234560123440')
     expect(boleto_novo.codigo_barras).to eql('34192252500000135001960025828101234560123440')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('34191.96005 25828.101235 45601.234409 2 25250000013500')
 
-    @valid_attributes[:nosso_numero] = '00010152'
-    @valid_attributes[:data_vencimento] = Date.parse('2029/05/20')
-    @valid_attributes[:carteira] = 109
-    @valid_attributes[:valor] = 6757.87
-    @valid_attributes[:seu_numero] = '00010152'
-    @valid_attributes[:agencia] = '1248'
-    @valid_attributes[:conta_corrente] = '02124'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '00010152'
+    valid_attributes[:data_vencimento] = Date.parse('2029/05/20')
+    valid_attributes[:carteira] = 109
+    valid_attributes[:valor] = 6757.87
+    valid_attributes[:seu_numero] = '00010152'
+    valid_attributes[:agencia] = '1248'
+    valid_attributes[:conta_corrente] = '02124'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.send(:codigo_barras_primeira_parte)).to eql('341925480000675787')
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1090001015271248021246000')
@@ -153,72 +153,72 @@ RSpec.describe Brcobranca::Boleto::Itau do
   end
 
   it 'Montar agencia_conta_corrente_dv' do
-    @valid_attributes[:conta_corrente] = '15255'
-    @valid_attributes[:agencia] = '0607'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:conta_corrente] = '15255'
+    valid_attributes[:agencia] = '0607'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_corrente_dv).to be(0)
     expect(boleto_novo.agencia_conta_boleto).to eql('0607 / 15255-0')
 
-    @valid_attributes[:conta_corrente] = '85547'
-    @valid_attributes[:agencia] = '1547'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:conta_corrente] = '85547'
+    valid_attributes[:agencia] = '1547'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_corrente_dv).to be(6)
     expect(boleto_novo.agencia_conta_boleto).to eql('1547 / 85547-6')
 
-    @valid_attributes[:conta_corrente] = '10207'
-    @valid_attributes[:agencia] = '1547'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:conta_corrente] = '10207'
+    valid_attributes[:agencia] = '1547'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_corrente_dv).to be(7)
 
-    @valid_attributes[:conta_corrente] = '53678'
-    @valid_attributes[:agencia] = '0811'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:conta_corrente] = '53678'
+    valid_attributes[:agencia] = '0811'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.agencia_conta_corrente_dv).to be(8)
     expect(boleto_novo.agencia_conta_boleto).to eql('0811 / 53678-8')
   end
 
   it 'Montar nosso_numero_boleto' do
-    @valid_attributes[:conta_corrente] = '15255'
-    @valid_attributes[:agencia] = '0607'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:conta_corrente] = '15255'
+    valid_attributes[:agencia] = '0607'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.nosso_numero_boleto).to eql('175/12345678-4')
 
-    @valid_attributes[:conta_corrente] = '15255'
-    @valid_attributes[:agencia] = '0607'
-    @valid_attributes[:carteira] = '143'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:conta_corrente] = '15255'
+    valid_attributes[:agencia] = '0607'
+    valid_attributes[:carteira] = '143'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.nosso_numero_boleto).to eql('143/12345678-2')
   end
 
   it 'Montar nosso_numero_dv' do
-    @valid_attributes[:nosso_numero] = '00015448'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '00015448'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.nosso_numero_dv).to be(6)
 
-    @valid_attributes[:nosso_numero] = '15448'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '15448'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.nosso_numero_dv).to be(6)
 
-    @valid_attributes[:nosso_numero] = '12345678'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '12345678'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.nosso_numero_dv).to be(4)
 
-    @valid_attributes[:nosso_numero] = '34230'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '34230'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.nosso_numero_dv).to be(5)
 
-    @valid_attributes[:nosso_numero] = '258281'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '258281'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.nosso_numero_dv).to be(7)
   end
@@ -228,8 +228,8 @@ RSpec.describe Brcobranca::Boleto::Itau do
   end
 
   it 'Gerar boleto nos formatos válidos com método to_' do
-    @valid_attributes[:data_documento] = Date.parse('2009/08/13')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_documento] = Date.parse('2009/08/13')
+    boleto_novo = described_class.new(valid_attributes)
 
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.send("to_#{format}".to_sym)
@@ -244,8 +244,8 @@ RSpec.describe Brcobranca::Boleto::Itau do
   end
 
   it 'Gerar boleto nos formatos válidos' do
-    @valid_attributes[:data_documento] = Date.parse('2009/08/13')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_documento] = Date.parse('2009/08/13')
+    boleto_novo = described_class.new(valid_attributes)
 
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.to(format)

--- a/spec/brcobranca/boleto/safra_spec.rb
+++ b/spec/brcobranca/boleto/safra_spec.rb
@@ -168,4 +168,8 @@ RSpec.describe Brcobranca::Boleto::Safra do
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/santander_spec.rb
+++ b/spec/brcobranca/boleto/santander_spec.rb
@@ -139,4 +139,8 @@ RSpec.describe Brcobranca::Boleto::Santander do
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/santander_spec.rb
+++ b/spec/brcobranca/boleto/santander_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::Santander do
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 25.0,
       cedente: 'Kivanio Barbosa',
       documento_cedente: '12345678912',
@@ -34,7 +34,7 @@ RSpec.describe Brcobranca::Boleto::Santander do
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.banco).to eql('033')
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
@@ -57,17 +57,17 @@ RSpec.describe Brcobranca::Boleto::Santander do
   end
 
   it 'Gerar boleto' do
-    @valid_attributes[:data_vencimento] = Date.parse('2011/10/09')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_vencimento] = Date.parse('2011/10/09')
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.codigo_barras_segunda_parte.size).to eq(25)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('9189977500000900002690102')
     expect(boleto_novo.codigo_barras).to eql('03399511500000025009189977500000900002690102')
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('03399.18997 77500.000904 00026.901025 9 51150000002500')
 
-    @valid_attributes[:valor] = 54.00
-    @valid_attributes[:nosso_numero] = '9000272'
-    @valid_attributes[:data_vencimento] = Date.parse('2012/09/08')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 54.00
+    valid_attributes[:nosso_numero] = '9000272'
+    valid_attributes[:data_vencimento] = Date.parse('2012/09/08')
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.codigo_barras_segunda_parte.size).to eq(25)
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('9189977500000900027250102')
     expect(boleto_novo.codigo_barras).to eql('03393545000000054009189977500000900027250102')
@@ -81,26 +81,26 @@ RSpec.describe Brcobranca::Boleto::Santander do
   end
 
   it 'Montar nosso_numero_dv' do
-    @valid_attributes[:nosso_numero] = '566612457800'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '566612457800'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to be(2)
 
-    @valid_attributes[:nosso_numero] = '90002720'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '90002720'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to be(7)
 
-    @valid_attributes[:nosso_numero] = '1961005'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '1961005'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_dv).to be(0)
   end
 
   it 'Montar nosso_numero_boleto' do
-    @valid_attributes[:nosso_numero] = '566612457800'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '566612457800'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_boleto).to eql('566612457800-2')
 
-    @valid_attributes[:nosso_numero] = '90002720'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:nosso_numero] = '90002720'
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.nosso_numero_boleto).to eql('90002720-7')
   end
 
@@ -109,8 +109,8 @@ RSpec.describe Brcobranca::Boleto::Santander do
   end
 
   it 'Gerar boleto nos formatos válidos com método to_' do
-    @valid_attributes[:data_documento] = Date.parse('2009/08/13')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_documento] = Date.parse('2009/08/13')
+    boleto_novo = described_class.new(valid_attributes)
 
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.send("to_#{format}".to_sym)
@@ -125,8 +125,8 @@ RSpec.describe Brcobranca::Boleto::Santander do
   end
 
   it 'Gerar boleto nos formatos válidos' do
-    @valid_attributes[:data_documento] = Date.parse('2009/08/13')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_documento] = Date.parse('2009/08/13')
+    boleto_novo = described_class.new(valid_attributes)
 
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.to(format)

--- a/spec/brcobranca/boleto/sicoob_spec.rb
+++ b/spec/brcobranca/boleto/sicoob_spec.rb
@@ -189,4 +189,8 @@ RSpec.describe Brcobranca::Boleto::Sicoob do # :nodoc:[all]
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/sicredi_spec.rb
+++ b/spec/brcobranca/boleto/sicredi_spec.rb
@@ -191,4 +191,8 @@ RSpec.describe Brcobranca::Boleto::Sicredi do
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/unicred_spec.rb
+++ b/spec/brcobranca/boleto/unicred_spec.rb
@@ -136,4 +136,8 @@ RSpec.describe Brcobranca::Boleto::Unicred do
       expect(File).not_to exist(tmp_file.path)
     end
   end
+
+  describe 'Aplica senha no pdf do boleto' do
+    it_behaves_like 'senha_pdf'
+  end
 end

--- a/spec/brcobranca/boleto/unicred_spec.rb
+++ b/spec/brcobranca/boleto/unicred_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Brcobranca::Boleto::Unicred do
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       especie_documento: 'DM',
       data_processamento: Date.parse('2012-01-18'),
       valor: 0.0,
@@ -36,7 +36,7 @@ RSpec.describe Brcobranca::Boleto::Unicred do
   end
 
   it 'Criar nova instancia com atributos válidos' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
     expect(boleto_novo.banco).to eql('136')
     expect(boleto_novo.especie_documento).to eql('DM')
     expect(boleto_novo.especie).to eql('R$')
@@ -59,14 +59,14 @@ RSpec.describe Brcobranca::Boleto::Unicred do
   end
 
   it 'Montar código de barras para carteira número 21' do
-    @valid_attributes[:valor] = 2952.95
-    @valid_attributes[:data_vencimento] = Date.parse('2012-01-24')
-    @valid_attributes[:data_documento] = Date.parse('2012-01-19')
-    @valid_attributes[:nosso_numero] = '13871'
-    @valid_attributes[:conta_corrente] = '12345'
-    @valid_attributes[:agencia] = '1234'
-    @valid_attributes[:carteira] = '21'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 2952.95
+    valid_attributes[:data_vencimento] = Date.parse('2012-01-24')
+    valid_attributes[:data_documento] = Date.parse('2012-01-19')
+    valid_attributes[:nosso_numero] = '13871'
+    valid_attributes[:conta_corrente] = '12345'
+    valid_attributes[:agencia] = '1234'
+    valid_attributes[:carteira] = '21'
+    boleto_novo = described_class.new(valid_attributes)
 
     expect(boleto_novo.codigo_barras.linha_digitavel).to eql('13691.23409 00012.345708 00001.387117 1 52220000295295')
     expect(boleto_novo.codigo_barras_segunda_parte).to eql('1234000012345700000138711')
@@ -79,7 +79,7 @@ RSpec.describe Brcobranca::Boleto::Unicred do
   end
 
   it 'Montar nosso_numero_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     boleto_novo.agencia = '1234'
     boleto_novo.conta_corrente = '12345'
@@ -90,7 +90,7 @@ RSpec.describe Brcobranca::Boleto::Unicred do
   end
 
   it 'Montar agencia_conta_boleto' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     boleto_novo.agencia = '1234'
     boleto_novo.conta_corrente = '12345'
@@ -102,7 +102,7 @@ RSpec.describe Brcobranca::Boleto::Unicred do
   end
 
   it 'Gerar boleto nos formatos válidos com método to_' do
-    boleto_novo = described_class.new(@valid_attributes)
+    boleto_novo = described_class.new(valid_attributes)
 
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.send("to_#{format}".to_sym)
@@ -117,13 +117,13 @@ RSpec.describe Brcobranca::Boleto::Unicred do
   end
 
   it 'Gerar boleto nos formatos válidos' do
-    @valid_attributes[:valor] = 2952.95
-    @valid_attributes[:data_documento] = Date.parse('2009-04-30')
-    @valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
-    @valid_attributes[:nosso_numero] = '86452'
-    @valid_attributes[:conta_corrente] = '03005'
-    @valid_attributes[:agencia] = '1172'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:valor] = 2952.95
+    valid_attributes[:data_documento] = Date.parse('2009-04-30')
+    valid_attributes[:data_vencimento] = Date.parse('2008-02-01')
+    valid_attributes[:nosso_numero] = '86452'
+    valid_attributes[:conta_corrente] = '03005'
+    valid_attributes[:agencia] = '1172'
+    boleto_novo = described_class.new(valid_attributes)
 
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.to(format)

--- a/spec/brcobranca/boletos_em_lote_spec.rb
+++ b/spec/brcobranca/boletos_em_lote_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe 'Muúltiplos boletos' do # :nodoc:[all]
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 0.0,
       cedente: 'Kivanio Barbosa',
       documento_cedente: '12345678912',
@@ -18,9 +18,9 @@ RSpec.describe 'Muúltiplos boletos' do # :nodoc:[all]
   end
 
   it 'imprimir múltiplos boleto em lote' do
-    boleto_1 = Brcobranca::Boleto::BancoBrasil.new(@valid_attributes)
-    boleto_2 = Brcobranca::Boleto::Bradesco.new(@valid_attributes)
-    boleto_3 = Brcobranca::Boleto::BancoBrasil.new(@valid_attributes)
+    boleto_1 = Brcobranca::Boleto::BancoBrasil.new(valid_attributes)
+    boleto_2 = Brcobranca::Boleto::Bradesco.new(valid_attributes)
+    boleto_3 = Brcobranca::Boleto::BancoBrasil.new(valid_attributes)
 
     boletos = [boleto_1, boleto_2, boleto_3]
 

--- a/spec/brcobranca/rghost_spec.rb
+++ b/spec/brcobranca/rghost_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe 'RGhost' do
-  before do
-    @valid_attributes = {
+  let(:valid_attributes) do
+    {
       valor: 0.0,
       cedente: 'Kivanio Barbosa',
       documento_cedente: '12345678912',

--- a/spec/support/shared_examples/formatos_validos.rb
+++ b/spec/support/shared_examples/formatos_validos.rb
@@ -2,9 +2,9 @@
 
 shared_examples_for 'formatos_validos' do
   it 'válido com método to_' do
-    @valid_attributes[:data_vencimento] = Date.parse('2009/08/14')
-    @valid_attributes[:data_documento] = Date.parse('2009/08/13')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_vencimento] = Date.parse('2009/08/14')
+    valid_attributes[:data_documento] = Date.parse('2009/08/13')
+    boleto_novo = described_class.new(valid_attributes)
 
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.send("to_#{format}".to_sym)
@@ -19,9 +19,9 @@ shared_examples_for 'formatos_validos' do
   end
 
   it 'válido' do
-    @valid_attributes[:data_documento] = Date.parse('2009/08/13')
-    @valid_attributes[:data_vencimento] = Date.parse('2009/08/13')
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:data_documento] = Date.parse('2009/08/13')
+    valid_attributes[:data_vencimento] = Date.parse('2009/08/13')
+    boleto_novo = described_class.new(valid_attributes)
 
     %w[pdf jpg tif png].each do |format|
       file_body = boleto_novo.to(format)

--- a/spec/support/shared_examples/senha_pdf.rb
+++ b/spec/support/shared_examples/senha_pdf.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+shared_examples_for 'senha_pdf' do
+  it 'aplica senha no pdf do boleto' do
+    @valid_attributes[:senha] = '12345'
+    boleto_novo = described_class.new(@valid_attributes)
+    file_body = boleto_novo.to('pdf').encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+    expect(file_body).to match('/Filter /Standard')
+    expect(file_body).to match('/Length 128')
+  end
+end

--- a/spec/support/shared_examples/senha_pdf.rb
+++ b/spec/support/shared_examples/senha_pdf.rb
@@ -2,8 +2,8 @@
 
 shared_examples_for 'senha_pdf' do
   it 'aplica senha no pdf do boleto' do
-    @valid_attributes[:senha] = '12345'
-    boleto_novo = described_class.new(@valid_attributes)
+    valid_attributes[:senha] = '12345'
+    boleto_novo = described_class.new(valid_attributes)
     file_body = boleto_novo.to('pdf').encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
     expect(file_body).to match('/Filter /Standard')
     expect(file_body).to match('/Length 128')

--- a/spec/support/shared_examples/senha_pdf.rb
+++ b/spec/support/shared_examples/senha_pdf.rb
@@ -2,7 +2,8 @@
 
 shared_examples_for 'senha_pdf' do
   it 'aplica senha no pdf do boleto' do
-    valid_attributes[:senha] = '12345'
+    valid_attributes[:senha_usuario] = '12345'
+    valid_attributes[:senha_proprietario] = '987654321'
     boleto_novo = described_class.new(valid_attributes)
     file_body = boleto_novo.to('pdf').encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
     expect(file_body).to match('/Filter /Standard')


### PR DESCRIPTION
Esse PR adiciona o atributo `senha` ao `Boleto`. Caso o atributo exista, o documento adiciona essa camada de segurança como user_password e owner_password.

![image](https://user-images.githubusercontent.com/33637113/219175122-e9f7a0d6-6a02-440f-a557-675c09dbdeb4.png)
![image](https://user-images.githubusercontent.com/33637113/219175144-a199d09e-90a6-4c64-a5e5-54728e633a92.png)
