### PR TITLE
[Boleto] Permissões para boleto com senha do usuário

### DIFF
--- a/lib/brcobranca.rb
+++ b/lib/brcobranca.rb
@@ -191,5 +191,6 @@ module Brcobranca
   module Util
     autoload :Empresa, 'brcobranca/util/empresa'
     autoload :Errors, 'brcobranca/util/errors'
+    autoload :Security, 'brcobranca/util/security'
   end
 end

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -71,12 +71,7 @@ module Brcobranca
         def modelo_generico(boleto, options = {})
           doc = Document.new paper: :A4 # 210x297
 
-          doc.security do |sec|
-            sec.owner_password = boleto.senha_proprietario
-            sec.user_password = boleto.senha_usuario
-            sec.key_length = 128
-            sec.disable :print, :modify, :annotate, :interactive, :assemble # Temporário enquanto Rghost não corrige o .disable
-          end if boleto.usa_senha?
+          Brcobranca::Util::Security.apply_password(document: doc, boleto: boleto)
 
           with_logo = boleto.recipient_logo_details.present?
           template_name = with_logo ? 'modelo_generico_logo.eps' : 'modelo_generico.eps'
@@ -114,12 +109,7 @@ module Brcobranca
         def modelo_generico_multipage(boletos, options = {})
           doc = Document.new paper: :A4 # 210x297
 
-          doc.security do |sec|
-            sec.owner_password = boletos.first.senha_proprietario
-            sec.user_password = boletos.first.senha_usuario
-            sec.key_length = 128
-            sec.disable :print, :modify, :annotate, :interactive, :assemble
-          end if boletos.first.usa_senha?
+          Brcobranca::Util::Security.apply_password(document: doc, boleto: boletos.first)
 
           template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico.eps')
 

--- a/lib/brcobranca/boleto/template/rghost.rb
+++ b/lib/brcobranca/boleto/template/rghost.rb
@@ -75,6 +75,7 @@ module Brcobranca
             sec.owner_password = boleto.senha_proprietario
             sec.user_password = boleto.senha_usuario
             sec.key_length = 128
+            sec.disable :print, :modify, :annotate, :interactive, :assemble # Temporário enquanto Rghost não corrige o .disable
           end if boleto.usa_senha?
 
           with_logo = boleto.recipient_logo_details.present?
@@ -117,6 +118,7 @@ module Brcobranca
             sec.owner_password = boletos.first.senha_proprietario
             sec.user_password = boletos.first.senha_usuario
             sec.key_length = 128
+            sec.disable :print, :modify, :annotate, :interactive, :assemble
           end if boletos.first.usa_senha?
 
           template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico.eps')

--- a/lib/brcobranca/boleto/template/rghost2.rb
+++ b/lib/brcobranca/boleto/template/rghost2.rb
@@ -73,12 +73,7 @@ begin
           def modelo_generico(boleto, options = {})
             doc = Document.new paper: [21,29.7] # A4
 
-            doc.security do |sec|
-              sec.owner_password = boleto.senha_proprietario
-              sec.user_password = boleto.senha_usuario
-              sec.key_length = 128
-              sec.disable :print, :modify, :annotate, :interactive, :assemble
-            end if boleto.usa_senha?
+            Brcobranca::Util::Security.apply_password(document: doc, boleto: boleto)
 
             template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico2.eps')
             raise 'Não foi possível encontrar o template. Verifique o caminho' unless File.exist?(template_path)
@@ -102,12 +97,7 @@ begin
           def modelo_generico_multipage(boletos, options = {})
             doc = Document.new paper: [21,29.7] # A4
 
-            doc.security do |sec|
-              sec.owner_password = boletos.first.senha_proprietario
-              sec.user_password = boletos.first.senha_usuario
-              sec.key_length = 128
-              sec.disable :print, :modify, :annotate, :interactive, :assemble
-            end if boletos.first.usa_senha?
+            Brcobranca::Util::Security.apply_password(document: doc, boleto: boletos.first)
 
             template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico2.eps')
             raise 'Não foi possível encontrar o template. Verifique o caminho' unless File.exist?(template_path)

--- a/lib/brcobranca/boleto/template/rghost2.rb
+++ b/lib/brcobranca/boleto/template/rghost2.rb
@@ -77,6 +77,7 @@ begin
               sec.owner_password = boleto.senha_proprietario
               sec.user_password = boleto.senha_usuario
               sec.key_length = 128
+              sec.disable :print, :modify, :annotate, :interactive, :assemble
             end if boleto.usa_senha?
 
             template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico2.eps')
@@ -105,6 +106,7 @@ begin
               sec.owner_password = boletos.first.senha_proprietario
               sec.user_password = boletos.first.senha_usuario
               sec.key_length = 128
+              sec.disable :print, :modify, :annotate, :interactive, :assemble
             end if boletos.first.usa_senha?
 
             template_path = File.join(File.dirname(__FILE__), '..', '..', 'arquivos', 'templates', 'modelo_generico2.eps')

--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -71,12 +71,7 @@ module Brcobranca
         def modelo_carne(boleto, options = {})
           doc = Document.new paper: [21, 9]
 
-          doc.security do |sec|
-            sec.owner_password = boleto.senha_proprietario
-            sec.user_password = boleto.senha_usuario
-            sec.key_length = 128
-            sec.disable :print, :modify, :annotate, :interactive, :assemble
-          end if boleto.usa_senha?
+          Brcobranca::Util::Security.apply_password(document: doc, boleto: boleto)
 
           colunas = calc_colunas 1
           linhas = calc_linhas 0
@@ -104,12 +99,7 @@ module Brcobranca
         def modelo_carne_multipage(boletos, options = {})
           doc = Document.new paper: :A4
 
-          doc.security do |sec|
-            sec.owner_password = boletos.first.senha_proprietario
-            sec.user_password = boletos.first.senha_usuario
-            sec.key_length = 128
-            sec.disable :print, :modify, :annotate, :interactive, :assemble
-          end if boletos.first.usa_senha?
+          Brcobranca::Util::Security.apply_password(document: doc, boleto: boletos.first)
 
           max_per_page = 3
           curr_page_position = 0

--- a/lib/brcobranca/boleto/template/rghost_carne.rb
+++ b/lib/brcobranca/boleto/template/rghost_carne.rb
@@ -75,6 +75,7 @@ module Brcobranca
             sec.owner_password = boleto.senha_proprietario
             sec.user_password = boleto.senha_usuario
             sec.key_length = 128
+            sec.disable :print, :modify, :annotate, :interactive, :assemble
           end if boleto.usa_senha?
 
           colunas = calc_colunas 1
@@ -107,6 +108,7 @@ module Brcobranca
             sec.owner_password = boletos.first.senha_proprietario
             sec.user_password = boletos.first.senha_usuario
             sec.key_length = 128
+            sec.disable :print, :modify, :annotate, :interactive, :assemble
           end if boletos.first.usa_senha?
 
           max_per_page = 3

--- a/lib/brcobranca/util/security.rb
+++ b/lib/brcobranca/util/security.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Brcobranca
+  module Util
+    class Security
+      def self.apply_password(document:, boleto:, key_length: 128)
+        return unless boleto.usa_senha?
+
+        document.security do |sec|
+          sec.owner_password = boleto.senha_proprietario
+          sec.user_password = boleto.senha_usuario
+          sec.key_length = key_length
+          sec.disable :print, :modify, :annotate, :interactive, :assemble # Temporário enquanto Rghost não corrige o .disable
+        end
+      end
+    end
+  end
+end

--- a/lib/brcobranca/version.rb
+++ b/lib/brcobranca/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Brcobranca
-  VERSION = '10.2.0'
+  VERSION = '10.2.1'
 end


### PR DESCRIPTION
Apesar das permissões estarem como `:print, :modify, :annotate, :interactive, :assemble`, elas na realidade produzem o resultado `:print, :copy, :copy_access, :high_quality_print` devido a uma implementação incorreta no RGhost. Será corrigido quando uma nova versão do RGhost for liberada. 